### PR TITLE
[ONEM-24177] - stop key repeat on focus loss

### DIFF
--- a/src/wayland/display.cpp
+++ b/src/wayland/display.cpp
@@ -168,6 +168,11 @@ static const struct wl_pointer_listener g_pointerListener = {
         auto it = seatData.inputClients.find(surface);
         if (it != seatData.inputClients.end() && seatData.pointer.target.first == it->first)
             seatData.pointer.target = { nullptr, nullptr };
+
+        if (seatData.repeatData.key && seatData.repeatData.eventSource) {
+            g_source_remove(seatData.repeatData.eventSource);
+            seatData.repeatData = { 0, 0, 0, 0 };
+        }
     },
     // motion
     [](void* data, struct wl_pointer*, uint32_t time, wl_fixed_t fixedX, wl_fixed_t fixedY)


### PR DESCRIPTION
When WPE moved to the background a RELEASE/UP key event won't be got,
it causes starting the repeater of key events mechanism and infinite key repeat.
To fix it, the key events repeater mechanism has to be reset when moved
to the background.